### PR TITLE
build: Exclude staging from deletion on merge

### DIFF
--- a/.github/delete-merged-branch-config.yml
+++ b/.github/delete-merged-branch-config.yml
@@ -1,0 +1,2 @@
+exclude:
+  - staging


### PR DESCRIPTION
This should resolve the issue where staging is deleted after it has been merged into production